### PR TITLE
Preserve original function name and parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 lib/sparkql/*.output
 pkg/*
+*.swp

--- a/lib/sparkql/function_resolver.rb
+++ b/lib/sparkql/function_resolver.rb
@@ -90,7 +90,14 @@ class Sparkql::FunctionResolver
   # Execute the function
   def call()
     real_vals = @args.map { |i| i[:value]}
-    self.send(@name.to_sym, *real_vals)
+    v = self.send(@name.to_sym, *real_vals)
+
+    unless v.nil?
+      v[:function_name] = @name
+      v[:function_parameters] = real_vals
+    end
+
+    v
   end
   
   protected 

--- a/test/unit/function_resolver_test.rb
+++ b/test/unit/function_resolver_test.rb
@@ -3,6 +3,14 @@ require 'test_helper'
 class ParserTest < Test::Unit::TestCase
   include Sparkql
 
+  test "function parameters and name preserved" do
+    f = FunctionResolver.new('radius', [{:type => :character, 
+          :value => "35.12 -68.33"},{:type => :decimal, :value => 1.0}])
+    value = f.call
+    assert_equal 'radius', value[:function_name]
+    assert_equal(["35.12 -68.33", 1.0], value[:function_parameters])
+  end
+
   test "now()" do
     start = Time.now
     f = FunctionResolver.new('now', [])
@@ -73,6 +81,13 @@ class ParserTest < Test::Unit::TestCase
     f = FunctionResolver.new('days', [{:type => :character, :value=>'bad value'}])
     f.validate
     assert f.errors?, "'days' function needs integer parameter"
+  end
+
+  test "assert nil returned when function called with errors" do
+    f = FunctionResolver.new('radius', [{:type => :character, 
+        :value => "35.12 -68.33, 35.13 -68.34"},{:type => :decimal, 
+        :value => 1.0}])
+    assert_nil f.call
   end
   
   test "invalid function" do

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -146,6 +146,14 @@ class ParserTest < Test::Unit::TestCase
     assert 5 > test_time - start, "Time range off by more than five seconds #{test_time - start}"
     assert -5 < test_time - start, "Time range off by more than five seconds #{test_time - start}"
   end
+
+  test "function data preserved in expression" do
+    filter = "OriginalEntryTimestamp Ge days(-7)"
+    @parser = Parser.new
+    expressions = @parser.parse("OriginalEntryTimestamp Ge days(-7)")
+    assert_equal 'days', expressions.first[:function_name]
+    assert_equal([-7], expressions.first[:function_parameters])
+  end
   
   test "Location Eq polygon()" do
     filter = "Location Eq polygon('35.12 -68.33, 35.13 -68.33, 35.13 -68.32, 35.12 -68.32')"


### PR DESCRIPTION
When processing a function expression, this change appends two new attributes to the tokenized expression:
- :function_name
- :function_parameters
