### PR TITLE
geo_ruby should be required in function resolver, where used

### DIFF
--- a/lib/sparkql/function_resolver.rb
+++ b/lib/sparkql/function_resolver.rb
@@ -1,4 +1,5 @@
 require 'time'
+require 'geo_ruby'
 require 'sparkql/geo'
 
 # Binding class to all supported function calls in the parser. Current support requires that the 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,3 @@
 require 'test/unit'
 require 'mocha'
 require 'sparkql'
-require 'geo_ruby'


### PR DESCRIPTION
Existing tests cover this IF geo_ruby is not included in test_helper.rb.
Removing the require simulates applications that do not us geo_ruby elsewhere,
and thus having globally required that library.
