### PR TITLE
API-2783 support type coercion across arrays

### DIFF
--- a/lib/sparkql/parser_compatibility.rb
+++ b/lib/sparkql/parser_compatibility.rb
@@ -205,9 +205,14 @@ module Sparkql::ParserCompatibility
       expression[:type] = :datetime
       expression[:cast] = :date
       return true
-    elsif expected == :date && expression[:type] == :datetime && datestr = expression[:value].match(/^(\d{4}-\d{2}-\d{2})/)
-      expression[:type] = :datetime
-      expression[:value] = datestr[0]
+    elsif expected == :date && expression[:type] == :datetime 
+      expression[:type] = :date
+      expression[:cast] = :datetime
+      if multiple_values?(expression[:value])
+        expression[:value].map!{ |val| coerce_datetime val }
+      else
+        expression[:value] = coerce_datetime expression[:value]
+      end
       return true
     elsif expected == :decimal && expression[:type] == :integer
       expression[:type] = :decimal
@@ -253,6 +258,14 @@ module Sparkql::ParserCompatibility
 
   def operator_supports_multiples?(operator)
     OPERATORS_SUPPORTING_MULTIPLES.include?(operator)
+  end
+  
+  def coerce_datetime datetime
+    if datestr = datetime.match(/^(\d{4}-\d{2}-\d{2})/)
+      datestr[0]
+    else
+      datetime
+    end
   end
 
 end

--- a/lib/sparkql/parser_tools.rb
+++ b/lib/sparkql/parser_tools.rb
@@ -1,5 +1,8 @@
 # This is the guts of the parser internals and is mixed into the parser for organization.
 module Sparkql::ParserTools
+
+  DATE_TYPES = [:datetime, :date]
+  NUMBER_TYPES = [:decimal, :integer]
   
   def parse(str)
     @lexer = Sparkql::Lexer.new(str)
@@ -56,17 +59,22 @@ module Sparkql::ParserTools
   end
 
   def tokenize_multiple(lit1, lit2)
+    final_type = lit1[:type]
     if lit1[:type] != lit2[:type]
-      tokenizer_error(:token => @lexer.last_field, 
-                      :message => "Type mismatch in field list.",
-                      :status => :fatal, 
-                      :syntax => true)    
+      final_type = coercible_types(lit1[:type],lit2[:type])
+      if final_type.nil?
+        final_type = lit1[:type]
+        tokenizer_error(:token => @lexer.last_field, 
+                        :message => "Type mismatch in field list.",
+                        :status => :fatal, 
+                        :syntax => true)
+      end
     end
     array = Array(lit1[:value])
     condition = lit1[:condition] || lit1[:value] 
     array << lit2[:value]
     {
-      :type => lit1[:type],
+      :type => final_type ,
       :value => array,
       :multiple => "true",
       :condition => condition + "," + (lit2[:condition] || lit2[:value])
@@ -149,6 +157,16 @@ module Sparkql::ParserTools
             :message => "You have exceeded the maximum parameter count.  Please limit to #{max_values} parameters to a single function.",
             :status => :fatal, :syntax => false, :constraint => true )
       args.slice!(max_values..-1)
+    end
+  end
+  
+  def coercible_types type1, type2
+    if DATE_TYPES.include?(type1) && DATE_TYPES.include?(type2)
+      DATE_TYPES.first
+    elsif NUMBER_TYPES.include?(type1) && NUMBER_TYPES.include?(type2)
+      NUMBER_TYPES.first
+    else
+      nil
     end
   end
 


### PR DESCRIPTION
@bhornseth, here's an addition to my last PR that allows the same support for value lists that are not homogeneous. This simplest example list containing Integers and Decimals for a Decimal field. The list gets grouped together as the highest precision type (Decimal) when evaluated at the expression level.

Dylan ran into the problem when trying to use functions on a date type as so: 

    DateType Bt days(-30),now()

Which to me seemed like a highly useful expression to support, hence this PR.
