### PR TITLE
Use nonobsolete StringScanner method

### DIFF
--- a/lib/sparkql/lexer.rb
+++ b/lib/sparkql/lexer.rb
@@ -53,7 +53,7 @@ class Sparkql::Lexer < StringScanner
         check_keywords(@current_token_value)
       when @current_token_value = scan(CUSTOM_FIELD)
         [:CUSTOM_FIELD,@current_token_value]
-      when empty?
+      when eos?
         [false, false] # end of file, \Z don't work with StringScanner
       else
         [:UNKNOWN, "ERROR: '#{self.string}'"]


### PR DESCRIPTION
StringScanner#empty? is an obsolete method -- use StringScanner#eos? instead.

Source: http://ruby-doc.org/stdlib-1.9.3/libdoc/strscan/rdoc/StringScanner.html#method-i-empty-3F