### PR TITLE
Modify test for mindatetime()

### DIFF
--- a/test/unit/function_resolver_test.rb
+++ b/test/unit/function_resolver_test.rb
@@ -226,7 +226,7 @@ class FunctionResolverTest < Test::Unit::TestCase
     value = f.call
     assert_equal :datetime, value[:type]
 
-    assert_equal '0001-01-01T00:00:00+00:00', value[:value]
+    assert_equal '1970-01-01T00:00:00+00:00', value[:value]
   end
 
   test "maxdatetime()" do


### PR DESCRIPTION
In the last commit I modified the value of MIN_DATE_TIME because
it was too far back for one of our datastores. I changed it to
the beginning of 1970 which should work well. I forgot to change
the test, so just patching this up.