### PR TITLE
API-7828 Timezone accounting for time -> date comparisons 

### DIFF
--- a/lib/sparkql/function_resolver.rb
+++ b/lib/sparkql/function_resolver.rb
@@ -225,14 +225,19 @@ module Sparkql
       }
     }.freeze
 
+    def self.lookup(function_name)
+      SUPPORTED_FUNCTIONS[function_name.to_sym]
+    end
+
     # Construct a resolver instance for a function
     # name: function name (String)
     # args: array of literal hashes of the format {:type=><literal_type>, :value=><escaped_literal_value>}.
     #       Empty arry for functions that have no arguments.
-    def initialize(name, args)
+    def initialize(name, args, options = {})
       @name = name
       @args = args
       @errors = []
+      @current_timestamp = options[:current_timestamp]
     end
 
     # Validate the function instance prior to calling it. All validation failures will show up in the
@@ -838,6 +843,7 @@ module Sparkql
     def current_timestamp
       @current_timestamp ||= DateTime.now
     end
+
 
     private
 

--- a/lib/sparkql/function_resolver.rb
+++ b/lib/sparkql/function_resolver.rb
@@ -642,7 +642,8 @@ module Sparkql
     end
 
     def months(num_months)
-      d = current_timestamp >> num_months
+      # DateTime usage. There's a better means to do this with Time via rails
+      d = (current_timestamp.to_datetime >> num_months).to_time
       {
         type: :date,
         value: d.strftime(STRFTIME_DATE_FORMAT)
@@ -650,7 +651,8 @@ module Sparkql
     end
 
     def years(num_years)
-      d = current_timestamp >> (num_years * 12)
+      # DateTime usage. There's a better means to do this with Time via rails
+      d = (current_timestamp.to_datetime >> (num_years * 12)).to_time
       {
         type: :date,
         value: d.strftime(STRFTIME_DATE_FORMAT)
@@ -837,11 +839,11 @@ module Sparkql
     end
 
     def current_time
-      current_timestamp.to_time
+      current_timestamp
     end
 
     def current_timestamp
-      @current_timestamp ||= DateTime.now
+      @current_timestamp ||= Time.now
     end
 
 

--- a/lib/sparkql/parser_compatibility.rb
+++ b/lib/sparkql/parser_compatibility.rb
@@ -159,11 +159,12 @@ module Sparkql::ParserCompatibility
   end
 
   def datetime_escape(string)
-    DateTime.parse(string)
+    unlocalized_datetime = DateTime.parse(string)
+    unlocalized_datetime.new_offset(offset)
   end
 
   def time_escape(string)
-    DateTime.parse(string)
+    datetime_escape(string)
   end
 
   def boolean_escape(string)
@@ -264,8 +265,9 @@ module Sparkql::ParserCompatibility
 
   def validate_manipulation_types(field_manipulations, expected)
     if field_manipulations[:type] == :function
-      function = Sparkql::FunctionResolver::SUPPORTED_FUNCTIONS[field_manipulations[:function_name].to_sym]
-      return false if function.nil?
+      return false unless supported_function?(field_manipulations[:function_name])
+
+      function = lookup_function(field_manipulations[:function_name])
       field_manipulations[:args].each_with_index do |arg, index|
         if arg[:type] == :field
           return false unless function[:args][index].include?(:field)
@@ -325,12 +327,16 @@ module Sparkql::ParserCompatibility
     OPERATORS_SUPPORTING_MULTIPLES.include?(operator)
   end
 
-  def coerce_datetime datetime
-    if datestr = datetime.match(/^(\d{4}-\d{2}-\d{2})/)
-      datestr[0]
+  # Datetime coercion to date factors in the current time zone when selecting a
+  # date.
+  def coerce_datetime datetime_string
+    if datetime_string.match(/^(\d{4}-\d{2}-\d{2})$/)
+      datetime_string
+    elsif datetime_string.match(/^(\d{4}-\d{2}-\d{2})/)
+      datetime = datetime_escape(datetime_string)
+      datetime.strftime(Sparkql::FunctionResolver::STRFTIME_DATE_FORMAT)
     else
-      datetime
+      datetime_string
     end
   end
-
 end

--- a/lib/sparkql/parser_compatibility.rb
+++ b/lib/sparkql/parser_compatibility.rb
@@ -166,8 +166,7 @@ module Sparkql::ParserCompatibility
   # class to be future compatible. The :time type in sparkql != a ruby Time
   # instance
   def datetime_escape(string)
-    unlocalized_time = Time.parse(string)
-    unlocalized_time.getlocal(offset)
+    Time.parse(string)
   end
 
   # Per the lexer, times don't have any timezone info. When parsing, pick the

--- a/lib/sparkql/parser_compatibility.rb
+++ b/lib/sparkql/parser_compatibility.rb
@@ -158,18 +158,22 @@ module Sparkql::ParserCompatibility
     Date.parse(string)
   end
 
-  # DateTime may have timezone info. Given that, we should honor it it when
+  # datetime may have timezone info. Given that, we should honor it it when
   # present or setting an appropriate default when not. Either way, we should
   # convert to local appropriate for the parser when we're done.
+  #
+  # DateTime in ruby is deprecated as of ruby 3.0. We've switched to the Time
+  # class to be future compatible. The :time type in sparkql != a ruby Time
+  # instance
   def datetime_escape(string)
-    unlocalized_datetime = DateTime.parse(string)
-    unlocalized_datetime.new_offset(offset)
+    unlocalized_time = Time.parse(string)
+    unlocalized_time.getlocal(offset)
   end
 
-  # Times don't have any timezone info. When parsing, pick the proper one to
-  # set things at.
+  # Per the lexer, times don't have any timezone info. When parsing, pick the
+  # proper offset to set things at.
   def time_escape(string)
-    DateTime.parse("#{string}#{offset}")
+    Time.parse("#{string}#{offset}")
   end
 
   def boolean_escape(string)

--- a/lib/sparkql/parser_compatibility.rb
+++ b/lib/sparkql/parser_compatibility.rb
@@ -158,13 +158,18 @@ module Sparkql::ParserCompatibility
     Date.parse(string)
   end
 
+  # DateTime may have timezone info. Given that, we should honor it it when
+  # present or setting an appropriate default when not. Either way, we should
+  # convert to local appropriate for the parser when we're done.
   def datetime_escape(string)
     unlocalized_datetime = DateTime.parse(string)
     unlocalized_datetime.new_offset(offset)
   end
 
+  # Times don't have any timezone info. When parsing, pick the proper one to
+  # set things at.
   def time_escape(string)
-    datetime_escape(string)
+    DateTime.parse("#{string}#{offset}")
   end
 
   def boolean_escape(string)

--- a/lib/sparkql/parser_tools.rb
+++ b/lib/sparkql/parser_tools.rb
@@ -443,10 +443,10 @@ module Sparkql::ParserTools
   end
 
   def current_timestamp
-    @current_timestamp ||= DateTime.now
+    @current_timestamp ||= Time.now
   end
 
   def offset
-    @offset ||= current_timestamp.zone
+    @offset ||= current_timestamp.strftime('%:z')
   end
 end

--- a/test/unit/function_resolver_test.rb
+++ b/test/unit/function_resolver_test.rb
@@ -15,7 +15,7 @@ class FunctionResolverTest < Test::Unit::TestCase
   MILLI = 123_456
   SECONDSF = 2.123456
 
-  EXAMPLE_DATE = DateTime.new(YEAR, MONTH, DAY, HOURS, MINUTES, SECONDSF)
+  EXAMPLE_DATE = Time.new(YEAR, MONTH, DAY, HOURS, MINUTES, SECONDSF)
   TIME_TESTS = {
     year: YEAR,
     month: MONTH,
@@ -27,7 +27,7 @@ class FunctionResolverTest < Test::Unit::TestCase
 
   def assert_times(call_value, expected_call_type = :datetime, overrides = {})
     assert_equal call_value[:type], expected_call_type
-    test_time = DateTime.parse(call_value[:value])
+    test_time = Time.parse(call_value[:value])
     tests = TIME_TESTS.merge(overrides)
     tests.each do |key, value|
       assert_equal value, test_time.send(key), "#{key}: #{test_time}"

--- a/test/unit/function_resolver_test.rb
+++ b/test/unit/function_resolver_test.rb
@@ -429,14 +429,15 @@ class FunctionResolverTest < Test::Unit::TestCase
 
   test 'days()' do
     [
-      [-1, '2021-12-30'],
-      [0, '2021-12-31'],
-      [1, '2022-01-01'],
-      [7, '2022-01-07']
-    ].each do |val, result|
+      [-1, '2021-12-30', EXAMPLE_DATE],
+      [0, '2021-12-31', EXAMPLE_DATE],
+      [1, '2022-01-01', EXAMPLE_DATE],
+      [7, '2022-01-07', EXAMPLE_DATE],
+      [0, '2022-01-01', Time.parse('2022-01-01T00:00:00-0500')]
+    ].each do |val, result, current_timestamp|
       f = FunctionResolver.new('days',
-        [{ type: :integer, value: val }],
-        current_timestamp: EXAMPLE_DATE)
+                               [{ type: :integer, value: val }],
+                               current_timestamp: current_timestamp)
       f.validate
       assert !f.errors?
       value = f.call

--- a/test/unit/function_resolver_test.rb
+++ b/test/unit/function_resolver_test.rb
@@ -6,7 +6,40 @@ require 'sparkql/geo'
 class FunctionResolverTest < Test::Unit::TestCase
   include Sparkql
 
-  EXAMPLE_DATE = DateTime.parse('2013-07-26T10:22:15.422804')
+  YEAR = 2021
+  MONTH = 12
+  DAY = 31
+  HOURS = 0
+  MINUTES = 1
+  SECONDS = 2
+  MILLI = 123_456
+  SECONDSF = 2.123456
+
+  EXAMPLE_DATE = DateTime.new(YEAR, MONTH, DAY, HOURS, MINUTES, SECONDSF)
+  TIME_TESTS = {
+    year: YEAR,
+    month: MONTH,
+    mday: DAY,
+    hour: HOURS,
+    min: MINUTES,
+    sec: SECONDS
+  }.freeze
+
+  def assert_times(call_value, expected_call_type = :datetime, overrides = {})
+    assert_equal call_value[:type], expected_call_type
+    test_time = DateTime.parse(call_value[:value])
+    tests = TIME_TESTS.merge(overrides)
+    tests.each do |key, value|
+      assert_equal value, test_time.send(key), "#{key}: #{test_time}"
+    end
+  end
+
+  test '#lookup' do
+    good = FunctionResolver.lookup('all')
+    bad = FunctionResolver.lookup('not_function')
+    assert !good.nil?
+    assert_nil bad
+  end
 
   test 'all with field' do
     f = FunctionResolver.new('all', [
@@ -297,186 +330,119 @@ class FunctionResolverTest < Test::Unit::TestCase
   end
 
   test 'seconds()' do
-    test_time = Time.new(2019, 4, 1, 8, 30, 20, 0)
-
-    f = FunctionResolver.new('seconds', [{ type: :integer, value: 7 }])
-    f.expects(:current_time).returns(test_time)
+    f = FunctionResolver.new('seconds',
+      [{ type: :integer, value: 7 }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors #{f.errors.inspect}"
-    value = f.call
+    assert !f.errors?
+    assert_times f.call, :datetime, sec: SECONDS + 7
 
-    assert_equal :datetime, value[:type]
-    d = DateTime.parse(value[:value])
-    assert_equal test_time.year, d.year
-    assert_equal test_time.month, d.month
-    assert_equal test_time.mday, d.mday
-    assert_equal test_time.hour, d.hour
-    assert_equal test_time.min, d.min
-    assert_equal test_time.sec + 7, d.sec
-
-    f = FunctionResolver.new('seconds', [{ type: :integer, value: -21 }])
-    f.expects(:current_time).returns(test_time)
+    f = FunctionResolver.new('seconds',
+      [{ type: :integer, value: -3 }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors #{f.errors.inspect}"
-    value = f.call
+    assert !f.errors?
+    assert_times f.call, :datetime, sec: 59, min: MINUTES - 1
 
-    assert_equal :datetime, value[:type]
-    d = DateTime.parse(value[:value])
-    assert_equal test_time.year, d.year
-    assert_equal test_time.month, d.month
-    assert_equal test_time.mday, d.mday
-    assert_equal test_time.hour, d.hour
-    assert_equal test_time.min - 1, d.min
-    assert_equal 29, d.min
-    assert_equal 59, d.sec
-
-    f = FunctionResolver.new('seconds', [{ type: :integer,
-                                           value: -Sparkql::FunctionResolver::SECONDS_IN_DAY }])
-    f.expects(:current_time).returns(test_time)
+    f = FunctionResolver.new('seconds',
+      [{ type: :integer, value: Sparkql::FunctionResolver::SECONDS_IN_DAY }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors #{f.errors.inspect}"
-    value = f.call
+    assert !f.errors?
 
-    assert_equal :datetime, value[:type]
-    d = DateTime.parse(value[:value])
-    assert_equal test_time.year, d.year
-    assert_equal test_time.month - 1, d.month
-    assert_equal 31, d.mday
-    assert_equal test_time.hour, d.hour
-    assert_equal test_time.min, d.min
-    assert_equal test_time.min, d.min
-    assert_equal test_time.sec, d.sec
+    assert_times f.call, :datetime, year: 2022, mday: 1, month: 1
   end
 
   test 'minutes()' do
-    test_time = Time.new(2019, 4, 1, 8, 30, 20, 0)
-
-    f = FunctionResolver.new('minutes', [{ type: :integer, value: 7 }])
-    f.expects(:current_time).returns(test_time)
+    f = FunctionResolver.new('minutes',
+      [{ type: :integer, value: 7 }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors #{f.errors.inspect}"
-    value = f.call
+    assert !f.errors?
+    assert_times f.call, :datetime, min: MINUTES + 7
 
-    assert_equal :datetime, value[:type]
-    d = DateTime.parse(value[:value])
-    assert_equal test_time.year, d.year
-    assert_equal test_time.month, d.month
-    assert_equal test_time.mday, d.mday
-    assert_equal test_time.hour, d.hour
-    assert_equal test_time.min + 7, d.min
-    assert_equal test_time.sec, d.sec
-
-    f = FunctionResolver.new('minutes', [{ type: :integer, value: -37 }])
-    f.expects(:current_time).returns(test_time)
+    f = FunctionResolver.new('minutes',
+      [{ type: :integer, value: -2 }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors #{f.errors.inspect}"
-    value = f.call
+    assert !f.errors?
+    assert_times f.call, :datetime, min: 59, hour: 23, mday: DAY - 1
 
-    assert_equal :datetime, value[:type]
-    d = DateTime.parse(value[:value])
-    assert_equal test_time.year, d.year
-    assert_equal test_time.month, d.month
-    assert_equal test_time.mday, d.mday
-    assert_equal test_time.hour - 1, d.hour
-    assert_equal 53, d.min
-
-    f = FunctionResolver.new('minutes', [{ type: :integer,
-                                           value: -1440 }])
-    f.expects(:current_time).returns(test_time)
+    f = FunctionResolver.new('minutes',
+      [{ type: :integer, value: -1440 }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors #{f.errors.inspect}"
-    value = f.call
-
-    assert_equal :datetime, value[:type]
-    d = DateTime.parse(value[:value])
-    assert_equal test_time.year, d.year
-    assert_equal test_time.month - 1, d.month
-    assert_equal 31, d.mday
-    assert_equal test_time.hour, d.hour
-    assert_equal test_time.min, d.min
+    assert !f.errors?
+    assert_times f.call, :datetime, mday: DAY - 1
   end
 
   test 'hours(), same day' do
-    test_time = Time.new(2019, 4, 1, 8, 30, 20, 0)
-    tests = [1, -1, 5, -5, 12]
-
+    tests = [1, 5, 12, 23, 0]
     tests.each do |offset|
-      f = FunctionResolver.new('hours', [{ type: :integer,
-                                           value: offset }])
-      f.expects(:current_time).returns(test_time)
+      f = FunctionResolver.new('hours',
+        [{ type: :integer, value: offset }],
+        current_timestamp: EXAMPLE_DATE)
       f.validate
-      assert !f.errors?, "Errors #{f.errors.inspect}"
-      value = f.call
-
-      assert_equal :datetime, value[:type]
-      d = DateTime.parse(value[:value])
-      assert_equal test_time.year, d.year
-      assert_equal test_time.month, d.month
-      assert_equal test_time.mday, d.mday
-      assert_equal test_time.hour + offset, d.hour
-      assert_equal test_time.min, d.min
-      assert_equal test_time.sec, d.sec
+      assert !f.errors?
+      assert_times f.call, :datetime, hour: HOURS + offset
     end
   end
 
+  test 'hours(), previous day' do
+    tests = [-1, -5, -12]
+    tests.each do |offset|
+      f = FunctionResolver.new('hours',
+        [{ type: :integer, value: offset }],
+        current_timestamp: EXAMPLE_DATE)
+      f.validate
+      assert !f.errors?
+      assert_times f.call, :datetime, hour: 24 + offset, mday: DAY - 1
+    end
+  end
+
+
   test 'hours(), wrap day' do
-    test_time = Time.new(2019, 4, 1, 8, 30, 20, 0)
-
     # Jump forward a few days, and a few hours.
-    f = FunctionResolver.new('hours', [{ type: :integer, value: 52 }])
-    f.expects(:current_time).returns(test_time)
+    f = FunctionResolver.new('hours',
+      [{ type: :integer, value: 52 }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors #{f.errors.inspect}"
-    value = f.call
-
-    assert_equal :datetime, value[:type]
-    d = DateTime.parse(value[:value])
-    assert_equal test_time.year, d.year
-    assert_equal test_time.month, d.month
-    assert_equal test_time.mday + 2, d.mday
-    assert_equal test_time.hour + 4, d.hour
-    assert_equal test_time.min, d.min
+    assert !f.errors?
+    assert_times f.call, :datetime, hour: HOURS + 4, mday: 2, month: 1, year: 2022
 
     # Drop back to the previous day, which'll also hit the previous month
-    f = FunctionResolver.new('hours', [{ type: :integer, value: -24 }])
-    f.expects(:current_time).returns(test_time)
+    f = FunctionResolver.new('hours',
+      [{ type: :integer, value: -24 }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors #{f.errors.inspect}"
-    value = f.call
-
-    assert_equal :datetime, value[:type]
-    d = DateTime.parse(value[:value])
-    assert_equal test_time.year, d.year
-    assert_equal test_time.month - 1, d.month
-    assert_equal 31, d.mday
-    assert_equal test_time.hour, d.hour
-    assert_equal test_time.min, d.min
+    assert !f.errors?
+    assert_times f.call, :datetime, mday: DAY - 1
 
     # Drop back one full year's worth of hours.
-    f = FunctionResolver.new('hours', [{ type: :integer, value: -8760 }])
-    f.expects(:current_time).returns(test_time)
+    f = FunctionResolver.new('hours',
+      [{ type: :integer, value: -8760 }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors #{f.errors.inspect}"
-    value = f.call
-
-    assert_equal :datetime, value[:type]
-    d = DateTime.parse(value[:value])
-    assert_equal test_time.year - 1, d.year
-    assert_equal test_time.month, d.month
-    assert_equal test_time.mday, d.mday
-    assert_equal test_time.hour, d.hour
-    assert_equal test_time.min, d.min
+    assert !f.errors?
+    assert_times f.call, :datetime, year: 2020
   end
 
   test 'days()' do
-    test_date = Date.new(2012, 10, 20) # Sat, 20 Oct 2012 00:00:00 GMT
-    f = FunctionResolver.new('days', [{ type: :integer, value: 7 }])
-    f.expects(:current_date).returns(test_date)
-    f.validate
-    assert !f.errors?, "Errors #{f.errors.inspect}"
-    value = f.call
-    assert_equal :date, value[:type]
-    assert_equal '2012-10-27', value[:value]
+    [
+      [-1, '2021-12-30'],
+      [0, '2021-12-31'],
+      [1, '2022-01-01'],
+      [7, '2022-01-07']
+    ].each do |val, result|
+      f = FunctionResolver.new('days',
+        [{ type: :integer, value: val }],
+        current_timestamp: EXAMPLE_DATE)
+      f.validate
+      assert !f.errors?
+      value = f.call
+      assert_equal :date, value[:type]
+      assert_equal result, value[:value], val
+    end
   end
 
   test 'weekdays()' do
@@ -549,27 +515,25 @@ class FunctionResolverTest < Test::Unit::TestCase
   end
 
   test 'months()' do
-    dt = DateTime.new(2014, 1, 6, 0, 0, 0, 0)
-    DateTime.expects(:now).once.returns(dt)
-
-    f = FunctionResolver.new('months', [{ type: :integer, value: 3 }])
+    f = FunctionResolver.new('months',
+      [{ type: :integer, value: 3 }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors resolving months(): #{f.errors.inspect}"
+    assert !f.errors?
     value = f.call
     assert_equal :date, value[:type]
-
-    assert_equal '2014-04-06', value[:value]
+    assert_equal '2022-03-31', value[:value]
   end
 
   test 'years()' do
-    dt = DateTime.new(2014, 1, 6, 0, 0, 0, 0)
-    DateTime.expects(:now).once.returns(dt)
-    f = FunctionResolver.new('years', [{ type: :integer, value: -4 }])
+    f = FunctionResolver.new('years',
+      [{ type: :integer, value: -4 }],
+      current_timestamp: EXAMPLE_DATE)
     f.validate
-    assert !f.errors?, "Errors resolving years(): #{f.errors.inspect}"
+    assert !f.errors?
     value = f.call
     assert_equal :date, value[:type]
-    assert_equal '2010-01-06', value[:value], 'negative values should go back in time'
+    assert_equal '2017-12-31', value[:value]
   end
 
   test 'year(), month(), and day()' do
@@ -847,7 +811,7 @@ class FunctionResolverTest < Test::Unit::TestCase
     assert !f.errors?, "Errors #{f.errors.inspect}"
     value = f.call
     assert_equal :time, value[:type]
-    assert_equal '10:22:15.422804000', value[:value]
+    assert_equal '00:01:02.123456000', value[:value]
   end
 
   test 'date(datetime)' do
@@ -856,7 +820,7 @@ class FunctionResolverTest < Test::Unit::TestCase
     assert !f.errors?, "Errors #{f.errors.inspect}"
     value = f.call
     assert_equal :date, value[:type]
-    assert_equal '2013-07-26', value[:value]
+    assert_equal '2021-12-31', value[:value]
   end
 
   ###

--- a/test/unit/parser_compatability_test.rb
+++ b/test/unit/parser_compatability_test.rb
@@ -582,10 +582,10 @@ class ParserCompatabilityTest < Test::Unit::TestCase
   end
 
   test "#current_timestamp" do
-    before_time = DateTime.now
+    before_time = Time.now
     parser = Parser.new
     parser_time = parser.current_timestamp
-    after_time = DateTime.now
+    after_time = Time.now
 
     assert before_time < parser_time
     assert after_time > parser_time

--- a/test/unit/parser_compatability_test.rb
+++ b/test/unit/parser_compatability_test.rb
@@ -594,13 +594,12 @@ class ParserCompatabilityTest < Test::Unit::TestCase
     assert_equal parser_time, parser.current_timestamp
   end
 
-  test "datetime->date conversions based on parser timezone" do
+  test "datetime->date conversions" do
     conversions = {
-      '2022-01-18T01:00:00.000000+0200' => Date.new(2022, 1, 17),
-      '2022-01-18T01:00:00.000000-0100' => Date.new(2022, 1, 18)
+      '2022-01-18T23:00:00.000000-0600' => Date.new(2022, 1, 18),
+      '2022-01-18T00:00:00.000000-0500' => Date.new(2022, 1, 18)
     }
     parser = Parser.new
-    parser.expects(:offset).returns("+00:00").twice
     conversions.each do |timestamp, date|
       expression = parser.tokenize("DateField Eq #{timestamp}").first
       assert !parser.errors?

--- a/test/unit/parser_test.rb
+++ b/test/unit/parser_test.rb
@@ -105,8 +105,8 @@ class ParserTest < Test::Unit::TestCase
   end
 
   def test_function_months
-    dt = DateTime.new(2014, 1, 5, 0, 0, 0, 0)
-    DateTime.expects(:now).returns(dt)
+    t = Time.new(2014, 1, 5, 0, 0, 0, 0)
+    Time.expects(:now).returns(t)
     @parser = Parser.new
     expressions = @parser.parse "ExpirationDate Gt months(-3)"
     assert !@parser.errors?, "errors :( #{@parser.errors.inspect}"
@@ -115,8 +115,8 @@ class ParserTest < Test::Unit::TestCase
   end
 
   def test_function_years
-    dt = DateTime.new(2014, 1, 5, 0, 0, 0, 0)
-    DateTime.expects(:now).returns(dt)
+    t = Time.new(2014, 1, 5, 0, 0, 0, 0)
+    Time.expects(:now).returns(t)
     @parser = Parser.new
     expressions = @parser.parse "SoldDate Lt years(2)"
     assert !@parser.errors?, "errors :( #{@parser.errors.inspect}"
@@ -125,8 +125,8 @@ class ParserTest < Test::Unit::TestCase
   end
 
   def test_function_days
-    dt = DateTime.new(2021, 2, 22, 0, 0, 0, 0)
-    DateTime.expects(:now).returns(dt)
+    t = Time.new(2021, 2, 22, 0, 0, 0, 0)
+    Time.expects(:now).returns(t)
     @parser = Parser.new
     expressions = @parser.parse "ExpirationDate Gt days(10)"
     assert !@parser.errors?
@@ -135,8 +135,8 @@ class ParserTest < Test::Unit::TestCase
   end
 
   def test_function_weekdays
-    dt = DateTime.new(2021, 2, 22, 0, 0, 0, 0)
-    DateTime.expects(:now).returns(dt)
+    t = Time.new(2021, 2, 22, 0, 0, 0, 0)
+    Time.expects(:now).returns(t)
     @parser = Parser.new
     expressions = @parser.parse "ExpirationDate Gt weekdays(10)"
     assert !@parser.errors?


### PR DESCRIPTION
After taking a few cracks at this, I've opted to do a few things:

* reorganize the function resolver so it's time / timezone agnostic
* set a parser current_timestamp, and the ability to query the "parser"
timezone. This will allow us to localize the timezone when needed
* localize all query timestamps to the parser time zone
* ensure dates reflect the appropriate timezone when extracted from a
timestamp
* Remove usage of the deprecated DateTime class (excluding one spot that's difficult to do so).